### PR TITLE
Fix issue when selecting time range in Graphite UI and update to newer Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ run	echo 'deb http://us.archive.ubuntu.com/ubuntu/ precise universe' >> /etc/apt
 run	apt-get -y update
 
 # Install required packages
-run	apt-get -y install python-ldap python-cairo python-django python-twisted python-django-tagging python-simplejson python-memcache python-pysqlite2 python-support python-pip gunicorn supervisor nginx-light
+run	apt-get -y install python-ldap python-cairo python-django python-twisted python-django-tagging python-simplejson python-memcache python-pysqlite2 python-support python-pip gunicorn supervisor nginx-light python-tz
 run	pip install whisper
 run	pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/lib" carbon
 run	pip install --install-option="--prefix=/var/lib/graphite" --install-option="--install-lib=/var/lib/graphite/webapp" graphite-web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # DOCKER-VERSION 0.4.0
+from	ubuntu:14.04
 
-from	ubuntu:12.04
+env upated 1
+
 run	echo 'deb http://us.archive.ubuntu.com/ubuntu/ precise universe' >> /etc/apt/sources.list
 run	apt-get -y update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # DOCKER-VERSION 0.4.0
 from	ubuntu:14.04
 
-env upated 1
+env REFRESHED_AT 2014_04_22
 
 run	echo 'deb http://us.archive.ubuntu.com/ubuntu/ precise universe' >> /etc/apt/sources.list
 run	apt-get -y update

--- a/README.md
+++ b/README.md
@@ -47,3 +47,14 @@ resulting in whisper files of approximately 2.5MiB.
 
 For more information, see [the
 repository](https://github.com/nickstenning/dockerfiles/tree/master/graphite).
+
+### Running on boot2docker
+If you want to store data in your home directory on the host you need to do the following
+
+* Create a directory to store the data (e.g. `/Users/<you>/docker/graphite`)
+* Set the permissions in boot2docker to allow www-run to access (comment by @sanros on https://github.com/boot2docker/boot2docker/issues/581)
+	* `boot2docker ssh`
+	* `sudo umount /Users`
+	* `sudo mount -t vboxsf -o uid=33,gid=33 Users /Users`
+* Start with the volume: `docker run --name graphite -p 8080:80 -p 2003:2003 -v /Users/<you>/docker/graphite:/var/lib/graphite/storage/whisper -d tilman/graphite`
+


### PR DESCRIPTION
* Updated to Ubuntu 14
* Added information on how to run this with boot2docker to the README
* Fixed an issue where selecting an absolute time range would break the graphite display (pytc was missing)